### PR TITLE
power: Reduce interactive timer with screen off

### DIFF
--- a/power/power.c
+++ b/power/power.c
@@ -229,6 +229,7 @@ static void power_hint(__attribute__((unused)) struct power_module *module, powe
         case POWER_HINT_VIDEO_DECODE:
             process_video_decode_hint(data);
         break;
+        default:
         break;
     }
 
@@ -289,7 +290,7 @@ void set_interactive(struct power_module *module, int on)
             }
         } else if ((strncmp(governor, INTERACTIVE_GOVERNOR, strlen(INTERACTIVE_GOVERNOR)) == 0) &&
                 (strlen(governor) == strlen(INTERACTIVE_GOVERNOR))) {
-            int resource_values[] = {THREAD_MIGRATION_SYNC_OFF};
+            int resource_values[] = {TR_MS_50, THREAD_MIGRATION_SYNC_OFF};
 
             if (!display_hint_sent) {
                 perform_hint_action(DISPLAY_STATE_HINT_ID,


### PR DESCRIPTION
- To reduce power consumption further.
- This is the standard QC configuration, but was disabled in CM due to
  Bluetooth audio issues when toggling the screen off. This no longer
  seems to be the case on M.

Change-Id: Ic2a8c23f8c6e765c42e3a71ffafa93098a0d1585
